### PR TITLE
fix: use `npm_execpath` for bin detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const {
-  env: { _: bin, DEBUG },
+  env: { npm_execpath: bin, DEBUG },
   argv,
   cwd,
 } = process
@@ -14,8 +14,8 @@ module.exports = {
   bin,
   args,
   cwd: cwd(),
-  isYarn: bin.endsWith('yarn'),
-  isNPM: bin.endsWith('npm'),
+  isYarn: bin.endsWith('yarn.js'),
+  isNPM: bin.endsWith('npm-cli.js'),
 }
 
 if (DEBUG === 'nyr') {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "test": "node test",
     "test:npm": "node test/npm",
-    "test:yarn": "node test/yarn"
+    "test:yarn": "node test/yarn",
+    "start": "DEBUG=nyr node ./index.js"
   },
   "engine": {
     "node": ">=6"

--- a/test/npm.js
+++ b/test/npm.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const { bin, args, cwd, isYarn, isNPM } = require('../index')
 
-assert(bin.endsWith('npm'), `'bin' is '${bin}'`)
+assert(bin.endsWith('npm-cli.js'), `'bin' is '${bin}'`)
 assert(args.indexOf('run') === 0, `'args' is '${args}'`)
 assert(cwd === process.cwd(), `'cwd' is '${cwd}'`)
 assert(isYarn === false, `'isYarn' is '${isYarn}'`)

--- a/test/yarn.js
+++ b/test/yarn.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const { bin, args, cwd, isYarn, isNPM } = require('../index')
 
-assert(bin.endsWith('yarn'), `'bin' is '${bin}'`)
+assert(bin.endsWith('yarn.js'), `'bin' is '${bin}'`)
 assert(args.indexOf('run') === 0, `'args' is '${args}'`)
 assert(cwd === process.cwd(), `'cwd' is '${cwd}'`)
 assert(isYarn === true, `'isYarn' is '${isYarn}'`)


### PR DESCRIPTION
Seems to be more reliable than `_`.

BREAKING CHANGE:
Possible this doesn't work correctly on some environments.
Please open an issue in that case.